### PR TITLE
[Call] delaying onResize call down the heap to fix body height calc

### DIFF
--- a/snow.js
+++ b/snow.js
@@ -109,7 +109,9 @@
 		};
 	})();
 
-	onResize();
+	setTimeout(function() {
+		onResize();
+	}, 0)
 
 	window.addEventListener('resize  ready', onResize, false);
 


### PR DESCRIPTION
That fixes incorrect body height calculation for some websites by delaying function call to the end of heap stack.